### PR TITLE
Fix profile editing for nickname and avatar

### DIFF
--- a/rental_system/rentals/forms.py
+++ b/rental_system/rentals/forms.py
@@ -1,10 +1,22 @@
 from django import forms
 from django.contrib.auth.models import User
 
+
 class ProfileForm(forms.ModelForm):
     nickname = forms.CharField(max_length=50, required=False, label="Pseudonim")
-    profile_picture = forms.ImageField(required=False, label="Zdjęcie profilowe")
+    avatar = forms.ImageField(required=False, label="Zdjęcie profilowe")
 
     class Meta:
         model = User
         fields = ["username", "email"]
+
+    def save(self, commit=True):
+        user = super().save(commit)
+        profile = user.profile
+        profile.nickname = self.cleaned_data.get("nickname", profile.nickname)
+        avatar = self.cleaned_data.get("avatar")
+        if avatar is not None:
+            profile.avatar = avatar
+        if commit:
+            profile.save()
+        return user

--- a/rental_system/rentals/templates/rentals/profile_form.html
+++ b/rental_system/rentals/templates/rentals/profile_form.html
@@ -24,8 +24,8 @@
         </div>
 
         <div class="mb-3">
-            <label for="id_profile_picture" class="form-label text-light">Zdjęcie profilowe</label>
-            {{ form.profile_picture }}
+            <label for="id_avatar" class="form-label text-light">Zdjęcie profilowe</label>
+            {{ form.avatar }}
         </div>
 
         <button type="submit" class="btn btn-primary">Zapisz zmiany</button>

--- a/rental_system/rentals/views.py
+++ b/rental_system/rentals/views.py
@@ -172,6 +172,17 @@ class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     def get_object(self):
         return self.request.user
 
+    def get_initial(self):
+        initial = super().get_initial()
+        profile = self.request.user.profile
+        initial['nickname'] = profile.nickname
+        initial['avatar'] = profile.avatar
+        return initial
+
+    def form_valid(self, form):
+        self.object = form.save()
+        return redirect(self.get_success_url())
+
 
 # Widok zgłoszenia serwisowego – dostępny tylko dla personelu (staff)
 class ServiceCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):


### PR DESCRIPTION
## Summary
- allow ProfileForm to save nickname and avatar to the user's profile
- prefill and persist profile changes in ProfileUpdateView
- update profile template to use the avatar field

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ac3c8f045c8329983111bc8745c08f